### PR TITLE
[feb/12] updating module version for cutom_vpc

### DIFF
--- a/aws_live_workloads/main.tf
+++ b/aws_live_workloads/main.tf
@@ -1,5 +1,5 @@
 module "custom_vpc" {
-  source = "../modules/core-infra/"
+  source = "github.com/samimunir25/ubiquitous-modules//modules/core-infra?ref=v0.0.4"
 
   vpc_cidr_block      = var.vpc_cidr_block
   vpc_tag             = var.vpc_tag


### PR DESCRIPTION
In this PR: 
- updating 'custom_vpc' root module to refer to 'URL/tagged version' of child module.